### PR TITLE
Fix large video tweeting

### DIFF
--- a/lib/twitter/rest/media.rb
+++ b/lib/twitter/rest/media.rb
@@ -77,6 +77,7 @@ module Twitter
         Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',
                                    command: 'INIT',
                                    media_type: 'video/mp4',
+                                   media_category: 'tweet_video',
                                    total_bytes: file.size,
                                    **options).perform
       end

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -331,7 +331,7 @@ module Twitter
         if !(File.basename(media) =~ /\.mp4$/)
           upload_media_simple(media)
         else
-          upload_media_chunked(media)
+          upload_media_chunked(media, media_category: 'tweet_video')
         end
       end
 

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -449,7 +449,10 @@ describe Twitter::REST::Tweets do
     context 'with a mp4 video' do
       it 'requests the correct resources' do
         @client.update_with_media('You always have options', fixture('1080p.mp4'))
-        expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')).to have_been_made.times(3)
+
+        expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').with { |request| request.body == URI.encode_www_form(command: 'INIT', media_type: 'video/mp4', media_category: 'tweet_video', total_bytes: 4062) }).to have_been_made
+        expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').with { |request| request.body =~ /APPEND/ }).to have_been_made
+        expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').with { |request| request.body == URI.encode_www_form(command: 'FINALIZE', media_id: '470030289822314497') }).to have_been_made
         expect(a_post('/1.1/statuses/update.json')).to have_been_made
       end
     end


### PR DESCRIPTION
The documentation says that media_category is required sometimes but if your video is large, we receive a "Large file can not be finalized synchronously" exception.

See https://dev.twitter.com/rest/reference/post/media/upload